### PR TITLE
Propagate signals to child process

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,6 +3,12 @@
 const spawn = require('child_process').spawn;
 
 module.exports = binName => {
-  spawn(require('.')[binName], process.argv.slice(2), {stdio: 'inherit'})
-    .on('exit', process.exit);
+  const child = spawn(require('./')[binName], process.argv.slice(2), {stdio: 'inherit'});
+  child.on('exit', process.exit);
+  process.on('SIGINT', function() {
+    child.kill('SIGINT');
+  });
+  process.on('SIGTERM', function() {
+    child.kill();
+  });
 };


### PR DESCRIPTION
Currently if I type Ctrl-C in the `psci` console it exits cleanly, but if the node wrapper process that I actually start is sent `SIGINT` or `SIGTERM`, it will exit without killing the actual child process of the binary. (In the case of `psci` it will later exit with an error trying to read input). With this change the child process should be killed immediately.