### PR TITLE
Add psc-ide-server, psc-ide-client executables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+sudo: required
+dist: trusty
 git:
   depth: 1
 # https://github.com/hvr/multi-ghc-travis

--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ const toExecutableName = require('to-executable-name');
   'psc',
   'psc-bundle',
   'psc-docs',
-  'psc-publish',
-  'psci',
+  'psc-ide-client',
   'psc-ide-server',
-  'psc-ide-client'
+  'psc-publish',
+  'psci'
 ].forEach(binName => {
   exports[binName] = path.join(__dirname, 'vendor', toExecutableName(binName));
 });

--- a/index.js
+++ b/index.js
@@ -9,7 +9,9 @@ const toExecutableName = require('to-executable-name');
   'psc-bundle',
   'psc-docs',
   'psc-publish',
-  'psci'
+  'psci',
+  'psc-ide-server',
+  'psc-ide-client'
 ].forEach(binName => {
   exports[binName] = path.join(__dirname, 'vendor', toExecutableName(binName));
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const version = '0.8.2';
+const version = '0.8.3';
 
 exports.SOURCE_URL = `https://github.com/purescript/purescript/archive/v${version}.tar.gz`;
 exports.BASE_URL = `https://github.com/purescript/purescript/releases/download/v${version}/`;

--- a/lib/install.js
+++ b/lib/install.js
@@ -17,7 +17,7 @@ const bin = new BinWrapper()
   .dest(path.dirname(paths.psc));
 
 eachSeries(Object.keys(paths), (key, next) => {
-  bin.use(path.basename(paths[key])).run(['--version'], runErr => {
+  bin.use(path.basename(paths[key])).run(['--help'], runErr => {
     if (runErr) {
       log.warn(runErr.message);
       log.warn(key + ' pre-build test failed');

--- a/lib/install.js
+++ b/lib/install.js
@@ -17,7 +17,7 @@ const bin = new BinWrapper()
   .dest(path.dirname(paths.psc));
 
 eachSeries(Object.keys(paths), (key, next) => {
-  bin.use(path.basename(paths[key])).run(['--help'], runErr => {
+  bin.use(path.basename(paths[key])).run(['--version'], runErr => {
     if (runErr) {
       log.warn(runErr.message);
       log.warn(key + ' pre-build test failed');

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "psc": "bin/psc.js",
     "psc-bundle": "bin/psc-bundle.js",
     "psc-docs": "bin/psc-docs.js",
-    "psc-publish": "bin/psc-publish.js",
-    "psci": "bin/psci.js",
+    "psc-ide-client": "bin/psc-ide-client.js",
     "psc-ide-server": "bin/psc-ide-server.js",
-    "psc-ide-client": "bin/psc-ide-client.js"
+    "psc-publish": "bin/psc-publish.js",
+    "psci": "bin/psci.js"
   },
   "scripts": {
     "postinstall": "node --harmony_destructuring lib/install.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "psc-bundle": "bin/psc-bundle.js",
     "psc-docs": "bin/psc-docs.js",
     "psc-publish": "bin/psc-publish.js",
-    "psci": "bin/psci.js"
+    "psci": "bin/psci.js",
+    "psc-ide-server": "bin/psc-ide-server.js",
+    "psc-ide-client": "bin/psc-ide-client.js"
   },
   "scripts": {
     "postinstall": "node --harmony_destructuring lib/install.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "PureScript wrapper that makes it seamlessly available as a local dependency",
   "license": "MIT",
   "repository": "purescript-contrib/node-purescript-bin",

--- a/test.js
+++ b/test.js
@@ -17,7 +17,7 @@ const {SOURCE_URL} = require('./lib');
 const VERSION = '0.8.2.0';
 
 test('The package entry point', t => {
-  t.plan(5);
+  t.plan(7);
 
   Object.keys(binaries).forEach(binName => {
     const cp = spawn(require('.')[binName], ['--help']);
@@ -44,7 +44,7 @@ Object.keys(binaries).forEach(binName => {
 });
 
 test('Build script', t => {
-  t.plan(6);
+  t.plan(8);
 
   const tmpDir = path.join(__dirname, 'tmp');
 

--- a/test.js
+++ b/test.js
@@ -14,7 +14,7 @@ const test = require('tape');
 const {bin: binaries} = require('./package.json');
 
 const {SOURCE_URL} = require('./lib');
-const VERSION = '0.8.2.0';
+const VERSION = '0.8.3.0';
 
 test('The package entry point', t => {
   t.plan(7);


### PR DESCRIPTION
These are now bundled with the compiler. Changed the test command to `--version` as these executables don't support `--help` per se (though they print out help info on unrecognised argument such as `--help`).

@kRITZCREEK